### PR TITLE
Add GitHub Actions workflow for CMake Debug build and ctest on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,47 @@ name: CI
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [master, main]
   pull_request:
-    branches: [ master, main ]
+    branches: [master, main]
 
 jobs:
+  ubuntu-debug:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up CMake cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            build
+            ~/.cache
+          key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build g++
+
+      - name: Configure CMake (Debug)
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Upload test logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: build/Testing/Temporary/LastTest.log
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -22,51 +58,48 @@ jobs:
             compiler: clang
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup C++
-      uses: aminya/setup-cpp@v1
-      with:
-        compiler: ${{ matrix.compiler }}
-        vcvarsall: ${{ contains(matrix.os, 'windows') }}
-        cmake: true
-        ninja: true
+      - name: Setup C++
+        uses: aminya/setup-cpp@v1
+        with:
+          compiler: ${{ matrix.compiler }}
+          vcvarsall: ${{ contains(matrix.os, 'windows') }}
+          cmake: true
+          ninja: true
 
-    - name: Configure CMake
-      run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTS=ON -G Ninja
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTS=ON -G Ninja
 
-    - name: Build
-      run: |
-        cmake --build build --config ${{ matrix.build_type }}
+      - name: Build
+        run: cmake --build build --config ${{ matrix.build_type }}
 
-    - name: Test
-      working-directory: build
-      run: |
-        ctest --build-config ${{ matrix.build_type }} --verbose
+      - name: Test
+        working-directory: build
+        run: ctest --build-config ${{ matrix.build_type }} --verbose
 
-    - name: Upload coverage reports (Ubuntu Debug only)
-      if: matrix.os == 'ubuntu-latest' && matrix.build_type == 'Debug'
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./build/coverage.info
-        fail_ci_if_error: true
+      - name: Upload coverage reports (Ubuntu Debug only)
+        if: matrix.os == 'ubuntu-latest' && matrix.build_type == 'Debug'
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./build/coverage.info
+          fail_ci_if_error: true
 
   static-analysis:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup tools
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-tidy cppcheck
+      - name: Setup tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy cppcheck
 
-    - name: Run clang-tidy
-      run: |
-        cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-        clang-tidy src/**/*.cpp -p build
+      - name: Run clang-tidy
+        run: |
+          cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          clang-tidy src/**/*.cpp -p build
 
-    - name: Run cppcheck
-      run: |
-        cppcheck --enable=all --std=c++20 --project=build/compile_commands.json
+      - name: Run cppcheck
+        run: |
+          cppcheck --enable=all --std=c++20 --project=build/compile_commands.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Modern C++20 Mathematical Proof Language Compiler
 [![Build Status](https://github.com/debjit-1004/MathForge/workflows/CI/badge.svg)](https://github.com/debjit-1004/MathForge/actions)
 [![Coverage Status](https://codecov.io/gh/debjit-1004/MathForge/branch/master/graph/badge.svg)](https://codecov.io/gh/debjit-1004/MathForge)
 [![License](https://img.shields.io/github/license/debjit-1004/MathForge)](LICENSE)
+![CI](https://github.com/debjit-1004/MathForge/actions/workflows/ci.yml/badge.svg)
 
 ## Overview
 


### PR DESCRIPTION
Fixes : #16
This PR adds a basic GitHub Actions workflow to build the project with CMake and run tests via ctest on Ubuntu.

Features:
- Single job workflow on ubuntu-latest
- Configures with CMake in Debug mode
- Builds with Ninja if available
- Runs ctest with output-on-failure
- Adds caching for build and dependency directories
- Uploads test logs as artifact on failure
- Added CI badge in README
