### PR TITLE
Add Clang-Format Enforcement in CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: Empty
+SortIncludes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,47 @@ name: CI
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [master, main]
   pull_request:
-    branches: [ master, main ]
+    branches: [master, main]
 
 jobs:
+  ubuntu-debug:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up CMake cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            build
+            ~/.cache
+          key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build g++
+
+      - name: Configure CMake (Debug)
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Upload test logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: build/Testing/Temporary/LastTest.log
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -22,51 +58,48 @@ jobs:
             compiler: clang
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup C++
-      uses: aminya/setup-cpp@v1
-      with:
-        compiler: ${{ matrix.compiler }}
-        vcvarsall: ${{ contains(matrix.os, 'windows') }}
-        cmake: true
-        ninja: true
+      - name: Setup C++
+        uses: aminya/setup-cpp@v1
+        with:
+          compiler: ${{ matrix.compiler }}
+          vcvarsall: ${{ contains(matrix.os, 'windows') }}
+          cmake: true
+          ninja: true
 
-    - name: Configure CMake
-      run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTS=ON -G Ninja
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTS=ON -G Ninja
 
-    - name: Build
-      run: |
-        cmake --build build --config ${{ matrix.build_type }}
+      - name: Build
+        run: cmake --build build --config ${{ matrix.build_type }}
 
-    - name: Test
-      working-directory: build
-      run: |
-        ctest --build-config ${{ matrix.build_type }} --verbose
+      - name: Test
+        working-directory: build
+        run: ctest --build-config ${{ matrix.build_type }} --verbose
 
-    - name: Upload coverage reports (Ubuntu Debug only)
-      if: matrix.os == 'ubuntu-latest' && matrix.build_type == 'Debug'
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./build/coverage.info
-        fail_ci_if_error: true
+      - name: Upload coverage reports (Ubuntu Debug only)
+        if: matrix.os == 'ubuntu-latest' && matrix.build_type == 'Debug'
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./build/coverage.info
+          fail_ci_if_error: true
 
   static-analysis:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup tools
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-tidy cppcheck
+      - name: Setup tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy cppcheck
 
-    - name: Run clang-tidy
-      run: |
-        cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-        clang-tidy src/**/*.cpp -p build
+      - name: Run clang-tidy
+        run: |
+          cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          clang-tidy src/**/*.cpp -p build
 
-    - name: Run cppcheck
-      run: |
-        cppcheck --enable=all --std=c++20 --project=build/compile_commands.json
+      - name: Run cppcheck
+        run: |
+          cppcheck --enable=all --std=c++20 --project=build/compile_commands.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,21 @@ jobs:
       - name: Run cppcheck
         run: |
           cppcheck --enable=all --std=c++20 --project=build/compile_commands.json
+
+  clang-format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Run clang-format check
+        run: |
+          echo "Checking C++ formatting..."
+          FILES=$(find src include -name "*.cpp" -o -name "*.h")
+          if [ -n "$FILES" ]; then
+            clang-format --dry-run --Werror $FILES
+          else
+            echo "No C++ source files found to check."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,18 @@ Check open issues and labels like `gssoc25`, `level1`, `level2`, `level3` for di
 - Logging via `Logger` (LOG_* macros) — keep messages actionable.
 - Clear errors with location; throw domain exceptions (LexicalException, SyntaxException, etc.).
 
+### Code Formatting
+
+This project enforces a consistent C++ style using **clang-format**.
+
+- The style is defined in the [.clang-format](.clang-format) file (LLVM base).
+- CI will fail if code is not formatted.
+- To format your code locally, run:
+
+```bash
+clang-format -i src/**/*.cpp include/**/*.h
+```
+
 ## Testing
 - Add unit tests in `tests/` using GoogleTest.
 - Include at least: happy path + 1–2 edge cases.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Modern C++20 Mathematical Proof Language Compiler
 [![Build Status](https://github.com/debjit-1004/MathForge/workflows/CI/badge.svg)](https://github.com/debjit-1004/MathForge/actions)
 [![Coverage Status](https://codecov.io/gh/debjit-1004/MathForge/branch/master/graph/badge.svg)](https://codecov.io/gh/debjit-1004/MathForge)
 [![License](https://img.shields.io/github/license/debjit-1004/MathForge)](LICENSE)
+![CI](https://github.com/debjit-1004/MathForge/actions/workflows/ci.yml/badge.svg)
 
 ## Overview
 


### PR DESCRIPTION
Fixes : #11 
This PR introduces consistent C++ code formatting across the project using clang-format, with automated checks in CI to enforce it.

Changes

- Added `.clang-format` file (LLVM-based style, tailored for project).
- Updated CI workflow to include a formatting check (`clang-format --dry-run -Werror`) so that builds fail if formatting is inconsistent.
- Updated CONTRIBUTING.md with instructions on running clang-format locally.

How It Works

- Developers can run:

`clang-format -i src/**/*.cpp include/**/*.h`

before committing to ensure code is properly formatted.

- CI will automatically check formatting on every push/PR.
- If deviations are detected, the job will fail with a diff for correction.

Acceptance Criteria

- CI fails on unformatted code.
- `.clang-format` defines the project’s formatting rules.
- Formatting guidelines documented in `CONTRIBUTING.md`.